### PR TITLE
Don't rely on client Accept headers

### DIFF
--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -19,10 +19,7 @@ function IsAppUrl(req) {
   if(RoutePolicy.classify(url)) {
     return false;
   }
-
-  // we only need to support HTML pages only
-  // this is a check to do it
-  return /html/.test(req.headers['accept']);
+  return true;
 }
 
 const {Router} = ReactRouter;
@@ -43,7 +40,7 @@ ReactRouterSSR.Run = function(routes, clientOptions, serverOptions) {
     // Parse cookies for the login token
     WebApp.rawConnectHandlers.use(cookieParser());
 
-    WebApp.rawConnectHandlers.use(Meteor.bindEnvironment(function(req, res, next) {
+    WebApp.connectHandlers.use(Meteor.bindEnvironment(function(req, res, next) {
       if (!IsAppUrl(req)) {
         next();
         return;
@@ -91,7 +88,7 @@ ReactRouterSSR.Run = function(routes, clientOptions, serverOptions) {
 
       var originalWrite = res.write;
       res.write = function(data) {
-        if(typeof data === 'string') {
+        if(typeof data === 'string' && data.indexOf('<!DOCTYPE html>') === 0) {
           data = data.replace('<body>', '<body><div id="' + (clientOptions.rootElement || 'react-app') + '">' + html + '</div>');
         }
 


### PR DESCRIPTION
 - Use ``WebApp.connectHandlers`` in stead of
   ``WebApp.rawConnectHandlers`` so that the handler runs after static
   middleware.  Meteor doesn't document this, but source is here:
   https://github.com/meteor/meteor/blob/a0162f27ecc9129e732421ea0849e8dc6c52e75b/packages/webapp/webapp_server.js
 - Remove check for ``html`` in client accept header.
 - Check that the string begins with ``<!DOCTYPE html>`` before
   injecting.

Fixes issue #4.