### PR TITLE
Redux integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Your main `<Route />` node of your application.<br />
 - `props` [object]: The additional arguments you would like to give to the `<Router />` component on the client.
 - `history`: History object to use. You can use `new ReactRouter.history.createHistory()`, `new ReactRouter.history.createHashHistory()` or `new ReactRouter.history.createMemoryHistory()`
 - `wrapper` [React component]: Wrapping your whole application client-side
+- `createReduxStore` [callback]: (if using Redux) A callback returning the application's redux store. See example below.
 
 #### serverOptions (optional)
 - `props` [object]: The additional arguments you would like to give to the `<Router />` component on the server.
@@ -28,6 +29,7 @@ Your main `<Route />` node of your application.<br />
 - `postRender` [function(req, res)]: Executed just after the renderToString
 - `dontMoveScripts` [bool]: Keep the script inside the head tag instead of moving it at the end of the body
 - `wrapper` [React component]: Wrapping your whole application server-side
+- `createReduxStore` [callback]: (if using Redux) A callback returning the application's redux store. See example below.
 
 ## Simple Example
 ```javascript
@@ -98,3 +100,63 @@ if (Meteor.isClient) {
   ga('send', 'pageview');
 }
 ```
+
+## Example with Redux
+
+ReactRouterSSR supports applications that use Redux, using the `createReduxStore` and `wrapper` options in both clientOptions and serverOptions. 
+- `createReduxStore` should be a callback in the shape `(initialState, history) => store`
+- `wrapper` should be the `Provider` component from react-redux (or some custom component wrapping the `Provider` and passing it the `store` prop it receives) 
+
+On both server and client side, ReactRouterSSR.Run() takes care of calling the `createReduxStore` callback and passing the resulting store as a prop to the `wrapper` component.
+
+```javascript
+import { Provider } from 'react-redux'
+import createStore from './myAppStore'
+
+const {IndexRoute, Route} = ReactRouter;
+
+AppRoutes = (
+  <Route path="/" component={App}>
+    <IndexRoute component={HomePage} />
+    <Route path="login" component={LoginPage} />
+    <Route path="*" component={NotFoundPage} />
+    {/* ... */}
+  </Route>
+);
+
+Meteor.startup(() => {
+  const clientOptions = {
+    wrapper: Provider,
+    createReduxStore: (initialState, history) => {
+      const store = createStore(initialState);
+      // If using redux-simple-router, this is where you can bind the history with syncReduxAndRouter
+      syncReduxAndRouter(history, store);
+      return store;
+    }
+  });
+  // Use the same 'wrapper' and 'createReduxStore' in serverOptions, or adjust to your needs.
+  const serverOptions = clientOptions;
+  
+  ReactRouterSSR.Run(routes, clientOptions, serverOptions);
+});
+```
+
+### Client-side store rehydration
+ReactRouterSSR automatically takes care of client-side store rehydration:
+
+- On server side, once rendering is done, the resulting store state is serialized and sent to the client as part of the generated HTML. 
+- On the client side, that serialized state is automatically picked up and passed to the `createReduxStore` callback as the 'initialState'.
+
+### Server-side pre-render data fetching (optional)
+On the server-side, ReactRouterSSR implements the "fetchData" mechanism mentioned at the bottom of [the Redux doc on Server-Side Rendering](http://rackt.org/redux/docs/recipes/ServerRendering.html): 
+
+The route components (e.g. `App`, `HomePage`, `LoginPage`... in the example above) can optionally specify a static fetchData() method to pre-populate the store with external data before rendering happens. 
+That fetchData() method, if present, will be automatically called for the components of the matched route (e.g. on `App` and `HomePage` for the url `'/'` in the example above).
+
+The fetchData() method receives:
+
+- the store's `getState` function,
+- the store's `dispatch` function,
+- the routing props for the resolved route (notably including `location` and `params`)
+
+and can dispatch async actions for external data fetching, returning the corresponding Promise. Rendering is then deferred until all Promises are resolved.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Meteor.startup(() => {
       syncReduxAndRouter(history, store);
       return store;
     }
-  });
+  };
   // Use the same 'wrapper' and 'createReduxStore' in serverOptions, or adjust to your needs.
   const serverOptions = clientOptions;
   

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -22,7 +22,8 @@ ReactRouterSSR.Run = function(routes, clientOptions) {
     let reduxStore;
     if (typeof clientOptions.createReduxStore !== 'undefined') {
       InjectData.getData('redux-initial-state', data => {
-        reduxStore = clientOptions.createReduxStore(JSON.parse(data), history);
+        const initialState = data ? JSON.parse(data) : undefined;
+        reduxStore = clientOptions.createReduxStore(initialState, history);
       });
     }
 

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -23,7 +23,7 @@ ReactRouterSSR.Run = function(routes, clientOptions) {
     if (typeof clientOptions.createReduxStore !== 'undefined') {
       let initialState;
       InjectData.getData('redux-initial-state', data => {initialState = JSON.parse(data)});
-      reduxStore = clientOptions.createReduxStore(history, initialState);
+      reduxStore = clientOptions.createReduxStore(initialState, history);
     }
 
     let app = (

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -21,9 +21,9 @@ ReactRouterSSR.Run = function(routes, clientOptions) {
     // If using redux, create the store with the initial state sent by the server. 
     let reduxStore;
     if (typeof clientOptions.createReduxStore !== 'undefined') {
-      let initialData;
-      InjectData.getData('redux-initial-state', data => {initialData = data});
-      reduxStore = clientOptions.createReduxStore(initialData, history);
+      let initialState;
+      InjectData.getData('redux-initial-state', data => {initialState = data});
+      reduxStore = clientOptions.createReduxStore(history, initialState);
     }
 
     let app = (

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -36,7 +36,7 @@ ReactRouterSSR.Run = function(routes, clientOptions) {
     if (clientOptions.wrapper) {
       const wrapperProps = {};
       // Pass the redux store to the wrapper, which is supposed to be some
-      // flavour or react-redux's <Provider>.
+      // flavour of react-redux's <Provider>.
       if (reduxStore) {
         wrapperProps.store = reduxStore;
       }

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -18,12 +18,12 @@ ReactRouterSSR.Run = function(routes, clientOptions) {
       document.body.appendChild(rootElement);
     }
 
-    // If using redux, create the store with the initial state sent by the server. 
+    // If using redux, create the store with the initial state injected by the server.
     let reduxStore;
     if (typeof clientOptions.createReduxStore !== 'undefined') {
-      let initialState;
-      InjectData.getData('redux-initial-state', data => {initialState = JSON.parse(data)});
-      reduxStore = clientOptions.createReduxStore(initialState, history);
+      InjectData.getData('redux-initial-state', data => {
+        reduxStore = clientOptions.createReduxStore(JSON.parse(data), history);
+      });
     }
 
     let app = (

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -22,7 +22,7 @@ ReactRouterSSR.Run = function(routes, clientOptions) {
     let reduxStore;
     if (typeof clientOptions.createReduxStore !== 'undefined') {
       let initialState;
-      InjectData.getData('redux-initial-state', data => {initialState = data});
+      InjectData.getData('redux-initial-state', data => {initialState = JSON.parse(data)});
       reduxStore = clientOptions.createReduxStore(history, initialState);
     }
 

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -18,6 +18,14 @@ ReactRouterSSR.Run = function(routes, clientOptions) {
       document.body.appendChild(rootElement);
     }
 
+    // If using redux, create the store with the initial state sent by the server. 
+    let reduxStore;
+    if (typeof clientOptions.createReduxStore !== 'undefined') {
+      let initialData;
+      InjectData.getData('redux-initial-state', data => {initialData = data});
+      reduxStore = clientOptions.createReduxStore(initialData, history);
+    }
+
     let app = (
       <Router
         history={history}
@@ -26,7 +34,13 @@ ReactRouterSSR.Run = function(routes, clientOptions) {
     );
 
     if (clientOptions.wrapper) {
-      app = <clientOptions.wrapper>{app}</clientOptions.wrapper>;
+      const wrapperProps = {};
+      // Pass the redux store to the wrapper, which is supposed to be some
+      // flavour or react-redux's <Provider>.
+      if (reduxStore) {
+        wrapperProps.store = reduxStore;
+      }
+      app = <clientOptions.wrapper {...wrapperProps}>{app}</clientOptions.wrapper>;
     }
 
     ReactDOM.render(app, rootElement);

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -82,13 +82,13 @@ ReactRouterSSR.Run = function(routes, clientOptions, serverOptions) {
         } else if (redirectLocation) {
           res.writeHead(302, { Location: redirectLocation.pathname + redirectLocation.search })
           res.end();
-        } else if (!renderProps) {
+        } else if (renderProps) {
+          sendSSRHtml(clientOptions, serverOptions, context, req, res, next, renderProps);
+        } else {
           res.writeHead(404);
           res.write('Not found');
           res.end();
         }
-
-        sendSSRHtml(clientOptions, serverOptions, context, req, res, next, renderProps);
       }));
 
       Meteor.userId = originalUserId;

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -188,10 +188,10 @@ function generateSSRData(serverOptions, context, req, res, renderProps) {
       if (typeof serverOptions.createReduxStore !== 'undefined') {
         // Create a history and set the current path, in case the callback wants
         // to bind it to the store using redux-simple-router's syncReduxAndRouter().
-        const reduxHistory = history.useQueries(history.createMemoryHistory)();
-        reduxHistory.replace(req.url);
+        const history = ReactRouter.history.useQueries(ReactRouter.history.createMemoryHistory)();
+        history.replace(req.url);
         // Create the store, with no initial state.
-        reduxStore = serverOptions.createReduxStore(undefined, reduxHistory);
+        reduxStore = serverOptions.createReduxStore(undefined, history);
         // Fetch components data.
         fetchComponentData(renderProps, reduxStore);
       }

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -190,8 +190,8 @@ function generateSSRData(serverOptions, context, req, res, renderProps) {
         // to bind it to the store using redux-simple-router's syncReduxAndRouter().
         const reduxHistory = history.useQueries(history.createMemoryHistory)();
         reduxHistory.replace(req.url);
-        // Create the store.
-        reduxStore = serverOptions.createReduxStore(reduxHistory);
+        // Create the store, with no initial state.
+        reduxStore = serverOptions.createReduxStore(undefined, reduxHistory);
         // Fetch components data.
         fetchComponentData(renderProps, reduxStore);
       }

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -201,7 +201,7 @@ function generateSSRData(serverOptions, context, req, res, renderProps) {
       if (serverOptions.wrapper) {
         const wrapperProps = {};
         // Pass the redux store to the wrapper, which is supposed to be some
-        // flavour or react-redux's <Provider>.
+        // flavour of react-redux's <Provider>.
         if (reduxStore) {
           wrapperProps.store = reduxStore;
         }

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -214,9 +214,10 @@ function generateSSRData(serverOptions, context, req, res, renderProps) {
       // If using redux, pass the resulting redux state to the client so that it
       // can hydrate from there.
       if (reduxStore) {
-        // @todo JSON.parse(JSON.stringify()) is used to reduce possible immutables down to
-        // pure Javascript. There is probably a smarter way.
-        res.pushData('redux-initial-state', JSON.parse(JSON.stringify(reduxStore.getState())));
+        // inject-data accepts raw objects and calls EJSON.stringify() on them,
+        // but the _.each() done in there does not play nice if the store contains
+        // ImmutableJS data. To avoid that, we serialize ourselves.
+        res.pushData('redux-initial-state', JSON.stringify(reduxStore.getState()));
       }
 
       if (Package['nfl:react-helmet']) {

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -256,7 +256,7 @@ function fetchComponentData(renderProps, reduxStore) {
     .map(component => component.fetchData(reduxStore.getState, reduxStore.dispatch, renderProps));
 
   // Wait until all promises have been resolved.
-  Promise.all(promises).await();
+  Promise.awaitAll(promises);
 }
 
 function SSRSubscribe(context) {

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -246,13 +246,24 @@ function generateSSRData(serverOptions, context, req, res, renderProps) {
 }
 
 function fetchComponentData(renderProps, reduxStore) {
-  const promises = renderProps.components
+  const componentsWithFetch = renderProps.components
     // Weed out 'undefined' routes.
     .filter(component => !!component)
     // Only look at components with a static fetchData() method
-    .filter(component => component.fetchData)
-    // Call the fetchData() methods, which lets the component dispatch possibly
-    // asynchronous actions, and collect the promises.
+    .filter(component => component.fetchData);
+
+  if (!componentsWithFetch.length) {
+    return;
+  }
+
+  if (!Package.promise) {
+    console.error("react-router-ssr: Support for fetchData() static methods on route components requires the 'promise' package.");
+    return;
+  }
+
+  // Call the fetchData() methods, which lets the component dispatch possibly
+  // asynchronous actions, and collect the promises.
+  const promises = componentsWithFetch
     .map(component => component.fetchData(reduxStore.getState, reduxStore.dispatch, renderProps));
 
   // Wait until all promises have been resolved.

--- a/package.js
+++ b/package.js
@@ -17,13 +17,15 @@ Package.onUse(function(api) {
     'react-meteor-data@0.2.4',
     'react-runtime@0.14.0',
     'reactrouter:react-router@1.0.2',
-    'meteorhacks:fast-render@2.9.0'
+    'meteorhacks:fast-render@2.9.0',
+    'meteorhacks:inject-data@1.4.0'
   ]);
 
   api.use('underscore@1.0.3', 'server');
   api.use('mongo@1.0.0', 'server');
   api.use('autopublish@1.0.0', 'server', {weak: true});
   api.use('nfl:react-helmet@2.2.0', 'server', {weak: true});
+  api.use('promise@0.5.1', 'server', {weak: true});
 
   api.imply(['reactrouter:react-router@1.0.2']);
 


### PR DESCRIPTION
As per the discussion in https://github.com/thereactivestack/kickstart-hugeapp/issues/27, here's a proposal for optional redux support :

Usage : 
Behavior is triggered by a 'createReduxStore' callback in clientOptions / serverOptions.
A 'wrapper' is also required, and it should be the react-redux `<Provider>` (or some custom component wrapping it)

```js
import { Provider } from 'react-redux'
import routes from './myAppRoutes'
import createStore from './myAppStore'

Meteor.startup(() => {
  const clientOptions = {
    wrapper: Provider, // Or some custom Component wrapping the redux Provider
    createReduxStore: (initialState, history) => {
      const store = createStore(initialState);
      // If using redux-simple-router, this is where you can bind the history with syncReduxAndRouter
      syncReduxAndRouter(history, store);
      return store;
    }
  });
  // Use the same 'wrapper' and 'createReduxStore' in serverOptions, or adjust to your needs.
  const serverOptions = clientOptions;
  ReactRouterSSR.Run(routes, clientOptions, serverOptions);
});
```

In detail, if options.createReduxStore callback is set :

On the server :
- After route is resolved and before rendering
  - create the store, passing a history to let the callback bind with redux-simple-router if it needs to
  - allow data fetching : let the components for the route fire actions (possibly async / Promise-based) to populate the store, and wait for them to be done.
    (see bottom of http://rackt.org/redux/docs/recipes/ServerRendering.html - implementation is inspired from https://github.com/erikras/react-redux-universal-hot-example)
  - pass the store as a prop to the wrapper component (the redux `<Provider>`)
- After rendering,
  - grab the resulting store state and pass it in the HTML (using meteorhacks:inject-data)

On the client :
- Before rendering 
  - create the store with the initial state populated from the server (if any)
  - pass the store as a prop to the wrapper component (the redux `<Provider>`)

