### PR TITLE
Change type & add attributes to rootElement for more style and flow control

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Your main `<Route />` node of your application.<br />
 **Notice that their is no `<Router />` element, ReactRouterSSR takes care of creating it on the client and server with the correct parameters**
 
 #### clientOptions (optional)
-- `rootElement` [string]: The root element ID your React application is mounted (default to `react-app`)
+- `rootElement` [string]: The root element ID your React application is mounted with (defaults to `react-app`)
+- `rootElementType` [string]: Set the root element type (defaults to `div`)
+- `rootElementAttributes`[array]: Set the root element attributes as an array of tag-value pairs. I.e. `[['class', sidebar main], ['style', 'background-color: white']]`
 - `props` [object]: The additional arguments you would like to give to the `<Router />` component on the client.
 - `history`: History object to use. You can use `new ReactRouter.history.createHistory()`, `new ReactRouter.history.createHashHistory()` or `new ReactRouter.history.createMemoryHistory()`
 - `wrapper` [React component]: Wrapping your whole application client-side

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -9,12 +9,25 @@ ReactRouterSSR.Run = function(routes, clientOptions) {
 
   Meteor.startup(function() {
     const rootElementName = clientOptions.rootElement || 'react-app';
+    const rootElementType = clientOptions.rootElementType || 'div';
+    const attributes = clientOptions.rootElementAttributes instanceof Array ? clientOptions.rootElementAttributes : [];
     let rootElement = document.getElementById(rootElementName);
 
     // In case the root element doesn't exist, let's create it
     if (!rootElement) {
-      rootElement = document.createElement('div');
+      rootElement = document.createElement(rootElementType);
       rootElement.id = rootElementName;
+
+      // check if a 2-dimensional array was passed... if not, be nice and handle it anyway
+      if(attributes[0] instanceof Array) {
+        // set attributes
+        for(var i = 0; i < attributes.length; i++) {
+          rootElement.setAttribute(attributes[i][0], attributes[i][1]);
+        }
+      } else if (attributes.length > 0){
+        rootElement.setAttribute(attributes[0], attributes[1]);
+      }
+
       document.body.appendChild(rootElement);
     }
 

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -122,7 +122,23 @@ function patchResWrite(clientOptions, serverOptions, originalWrite, css, html, h
         );
       }
 
-      data = data.replace('<body>', '<body><div id="' + (clientOptions.rootElement || 'react-app') + '">' + html + '</div>');
+      /*
+       To set multiple root element attributes such as class and style tags, simply pass it a 2-dimensional array
+       of attribute value pairs. I.e. [["class", "sidebar main"], ["style", "background-color: white"]]
+       */
+      let rootElementAttributes = '';
+      const attributes = clientOptions.rootElementAttributes instanceof Array ? clientOptions.rootElementAttributes : [];
+      // check if a 2-dimensional array was passed... if not, be nice and handle it anyway
+      if(attributes[0] instanceof Array) {
+        // set as concatenated string attributes
+        for(var i = 0; i < attributes.length; i++) {
+          rootElementAttributes = rootElementAttributes + ' ' + attributes[i][0] + '="' + attributes[i][1] + '"';
+        }
+      } else if (attributes.length > 0){
+        rootElementAttributes = attributes[0] + '="' + attributes[1] + '"';
+      }
+
+      data = data.replace('<body>', '<body><' + (clientOptions.rootElementType || 'div') + ' id="' + (clientOptions.rootElement || 'react-app') + '" ' + rootElementAttributes + ' >' + html + '</' + (clientOptions.rootElementType || 'div') + '>');
 
       if (typeof serverOptions.webpackStats !== 'undefined') {
         data = addAssetsChunks(serverOptions, data);

--- a/package.js
+++ b/package.js
@@ -29,8 +29,6 @@ Package.onUse(function(api) {
 
   api.use(['routepolicy@1.0.5'], ['server']);
 
-  api.use(['dburles:mongo-collection-instances'], ['server']);
-
   api.add_files(['lib/react-router-ssr.js']);
 
   api.add_files(['lib/client.jsx'], 'client');

--- a/package.js
+++ b/package.js
@@ -29,6 +29,8 @@ Package.onUse(function(api) {
 
   api.use(['routepolicy@1.0.5'], ['server']);
 
+  api.use(['dburles:mongo-collection-instances'], ['server']);
+
   api.add_files(['lib/react-router-ssr.js']);
 
   api.add_files(['lib/client.jsx'], 'client');

--- a/package.js
+++ b/package.js
@@ -30,7 +30,6 @@ Package.onUse(function(api) {
   api.use(['routepolicy@1.0.5'], ['server']);
 
   api.use(['dburles:mongo-collection-instances'], ['server']);
-  api.imply(['dburles:mongo-collection-instances'], ['server']);
 
   api.add_files(['lib/react-router-ssr.js']);
 

--- a/package.js
+++ b/package.js
@@ -30,6 +30,7 @@ Package.onUse(function(api) {
   api.use(['routepolicy@1.0.5'], ['server']);
 
   api.use(['dburles:mongo-collection-instances'], ['server']);
+  api.imply(['dburles:mongo-collection-instances'], ['server']);
 
   api.add_files(['lib/react-router-ssr.js']);
 


### PR DESCRIPTION
Only having a `div` root element as render target is too restrictive for some sensitive cascade reflow cases. Also, it should be possible to directly sugar the root element with i.e. class and style attributes. This pull request adds `rootElementType` and `rootElementAttributes` to the `clientOptions`, both applied server (SSR) and client side.

*entry/client/routes.jsx*
```jsx
ReactRouterSSR.Run(
	<Route>
		{todoRoutes}
	</Route>
	, {
		rootElement: "app",
		rootElementType: "span",
		rootElementAttributes: [
			["class", "sidebar main"],
			["style", "background-color: white"]
		]
	});
```

*SSR/Client result*
```html
<body>
	<span id="app  class="sidebar main" style="background-color: white">
		<div class="TestComponent" data-reactid="(...)" data-react-checksum="(...)">
		(...)
```

fixes https://github.com/thereactivestack/kickstart-hugeapp/issues/39#issuecomment-166948907