### PR TITLE
Redux hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Your main `<Route />` node of your application.<br />
 **Notice that their is no `<Router />` element, ReactRouterSSR takes care of creating it on the client and server with the correct parameters**
 
 #### clientOptions (optional)
-- `history`: History object for react-router
+- `historyHook`: [function(history) : newHistory] - Hook something into history client side.
 - `props` [object]: The additional arguments you would like to give to the `<Router />` component on the client.
 - `wrapperHook` [function(App) : Component]: You can wrap the react-router element with your own providers.
 - `rehydrateHook` [function(data)]: Receive the rehydrated object that was dehydrated during server side rendering.
@@ -28,7 +28,7 @@ Your main `<Route />` node of your application.<br />
 #### serverOptions (optional)
 - `props` [object]: The additional arguments you would like to give to the `<Router />` component on the server.
 - `htmlHook` [function(html) : newHtml]: Prepare the HTML before sending it to the client
-- `historyHook` [function(history): newHistory]: Hook something on the history
+- `historyHook` [function(history): newHistory]: Hook something on the history server side.
 - `dehydrateHook` [function() : data]: Supply data that should be dehydrated and sent to client.
 - `fetchDataHook` [function(components) : Array<Promise>]: Trigger the fetchData on your components that have it
 - `preRender` [function(req, res)]: Executed just before the renderToString

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Your main `<Route />` node of your application.<br />
 - `history`: History object for react-router
 - `props` [object]: The additional arguments you would like to give to the `<Router />` component on the client.
 - `wrapperHook` [function(App) : Component]: You can wrap the react-router element with your own providers.
-
+- `rehydrateHook` [function(data)]: Receive the rehydrated object that was dehydrated during server side rendering.
 - `rootElement` [string]: The root element ID your React application is mounted with (defaults to `react-app`)
 - `rootElementType` [string]: Set the root element type (defaults to `div`)
 - `rootElementAttributes`[array]: Set the root element attributes as an array of tag-value pairs. I.e. `[['class', sidebar main], ['style', 'background-color: white']]`
@@ -29,6 +29,7 @@ Your main `<Route />` node of your application.<br />
 - `props` [object]: The additional arguments you would like to give to the `<Router />` component on the server.
 - `htmlHook` [function(html) : newHtml]: Prepare the HTML before sending it to the client
 - `historyHook` [function(history): newHistory]: Hook something on the history
+- `dehydrateHook` [function() : data]: Supply data that should be dehydrated and sent to client.
 - `fetchDataHook` [function(components) : Array<Promise>]: Trigger the fetchData on your components that have it
 - `preRender` [function(req, res)]: Executed just before the renderToString
 - `postRender` [function(req, res)]: Executed just after the renderToString

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -34,12 +34,11 @@ const ReactRouterSSR = {
         document.body.appendChild(rootElement);
       }
 
-      // If using redux, create the store with the initial state injected by the server.
-      let reduxStore;
-      if (typeof clientOptions.createReduxStore !== 'undefined') {
-        InjectData.getData('redux-initial-state', data => {
-          const initialState = data ? JSON.parse(data) : undefined;
-          reduxStore = clientOptions.createReduxStore(initialState, history);
+      // Rehydrate data client side, if desired.
+      if(typeof clientOptions.rehydrateHook === 'function') {
+        InjectData.getData('dehydrated-initial-data', data => {
+          const rehydratedData = data ? JSON.parse(data) : undefined;
+          clientOptions.rehydrateHook(rehydratedData);
         });
       }
 

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -8,7 +8,11 @@ const ReactRouterSSR = {
       clientOptions = {};
     }
 
-    const history = clientOptions.history || browserHistory;
+    let history = browserHistory;
+
+    if(typeof clientOptions.historyHook === 'function') {
+      history = clientOptions.historyHook(history);
+    }
 
     Meteor.startup(function() {
       const rootElementName = clientOptions.rootElement || 'react-app';

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -213,6 +213,10 @@ function generateSSRData(clientOptions, serverOptions, req, res, renderProps) {
       html = ReactDOMServer.renderToString(app);
       css = global.__STYLE_COLLECTOR__;
 
+      if (typeof serverOptions.dehydrateHook === 'function') {
+        InjectData.pushData(res, 'dehydrated-initial-data', JSON.stringify(serverOptions.dehydrateHook()));
+      }
+
       if (serverOptions.postRender) {
         serverOptions.postRender(req, res);
       }


### PR DESCRIPTION
Redux can be used in the current implementation using just wrapperHook and postRender but it is a bit messy.   

This is just an idea to add hydration hooks that can be used for the purposes of redux or other data.   It also includes an updated example in the README using these new hooks.

Also, matched method of getting history between client and server for simpler API.