### PR TITLE
Add optional "renderHook"

### DIFF
--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -57,7 +57,11 @@ const ReactRouterSSR = {
         app = clientOptions.wrapperHook(app);
       }
 
-      ReactDOM.render(app, rootElement);
+      if (typeof clientOptions.renderHook === 'function') {
+        clientOptions.renderHook(app, rootElement);
+      } else {
+        ReactDOM.render(app, rootElement);
+      }
 
       let collectorEl = document.getElementById(clientOptions.styleCollectorId || 'css-style-collector-data')
 


### PR DESCRIPTION
I was fighting almost the whole last week with a very resistant "invariant violation" during my attempt to integrate "react-dnd" into a project using your awesome "reactive-stack". So i am using this package here too and i was pretty much confused when i finally stumpled upon the solution.

Short story: I was trying to integrate react-dnd and my initial example always got this "invariant violation", i almost got insane... I finally tried to let run the exact same sample-code they offer in their official repository - and i still got the invariant violation.

So i started to try the integration on different stacks - just to find out, that as soon as a stack is using "meteor-react-router-ssr", the invariant violation just magically starts to appear.

Finally i found out that it is all based on the "ReactDOM.render" call.

It is somehow extremely important that the central "render" call happens somehow in my own stack (my own files) and not in a package file like "meteor-react-router-ssr" does oO

I still can't explain to myself what is the reason behind this....

But at least i'm pretty lucky now that i found a solution that works for me and it isn't even ugly like hell 😄 

I propose to invent a new optional "renderHook" - which, when defined is called instead of directly run "ReactDOM.render".

So this gives users like i am the possibility to just override the central render-call, do it in my own file and TADA - all invariant violations are gone with react-dnd 👍 

It is really strange - no other package ever excepted in the same way on this stack so far. React-dnd seems to be the first one with this problem - but is also one which is heavily using "element-refs" internally to keep track of the dragged items.

Hopefully this could help in future to prevent such problems for other people! (Some documentation would be needed for that too right..)

Now my project just does this in my "routes.js":

`const renderHook = (app, rootElement) => {`
`  ReactDOM.render(app, rootElement);`
`};`

`const clientOptions = { historyHook, rehydrateHook, wrapperHook, renderHook };`

As you can see - it's the exact same code like the SSR package is executing internally - but still with the big difference that one get the invariant violation, the other not -.-