### PR TITLE
No dependency warning when using react-router@3-beta

### DIFF
--- a/lib/react-router-ssr.js
+++ b/lib/react-router-ssr.js
@@ -2,7 +2,7 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 checkNpmVersions({
   'react': '15.x',
   'react-dom': '15.x',
-  'react-router': '2.x'
+  'react-router': '2.x || >=3.0.0-beta.1'
 }, 'reactrouter:react-router-ssr');
 
 if (Meteor.isClient) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "react-helmet": "^3.1.0",
-    "react-router": "^2.0.1",
+    "react-router": "^2.0.1 || >=3.0.0-beta.1",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
Hey @eXon! This PR is a minor fix for the warnings thrown by the npm-check-version's meteor package when using react-router@3 👍 

Your package is working really well with react-router @2.x and also @3, currently in [beta](https://github.com/ReactTraining/react-router/blob/v3/CHANGES.md)! 👌 

I'm using it daily on Telescope Nova, and a lot of folks are often intrigued by the warning they get when starting the app:

> hey, there is this warning npm versions on react-router, what should I do? ~~So scared!! Is it the end of the world?!~~

Looking at [semver docs](https://www.npmjs.com/package/semver#prerelease-tags) on how to handle pre-release versions, I fixed the warning in a "verbose" way. It's not that scary after all 😄  